### PR TITLE
Fix usclass request

### DIFF
--- a/lib/handlers/application_handler_v40.py
+++ b/lib/handlers/application_handler_v40.py
@@ -247,7 +247,7 @@ class Patent(PatentHandler):
         """
         classes = []
         i = 0
-        main = self.xml.classification_national.contents_of('main_classification')
+        main = self.xml.classification_national.contents_of('main_classification', trim=False)
         if len(main[0]) > 0:
             crossrefsub = main[0][3:].replace(" ","")
             if len(crossrefsub) > 3 and re.search('^[A-Z]',crossrefsub[3:]) is None:
@@ -267,7 +267,7 @@ class Patent(PatentHandler):
                     {'id': "{class}/{subclass}".format(**data).upper()}])
                 i = i + 1
             if self.xml.classification_national.further_classification:
-                further = self.xml.classification_national.contents_of('further_classification')
+                further = self.xml.classification_national.contents_of('further_classification', trim=False)
                 for classification in further:
                     crossrefsub = classification[3:].replace(" ","")
                     if len(crossrefsub) > 3 and re.search('^[A-Z]',crossrefsub[3:]) is None:

--- a/lib/handlers/application_handler_v43.py
+++ b/lib/handlers/application_handler_v43.py
@@ -248,7 +248,7 @@ class Patent(PatentHandler):
         """
         classes = []
         i = 0
-        main = self.xml.classification_national.contents_of('main_classification')
+        main = self.xml.classification_national.contents_of('main_classification', trim=False)
         if re.search('^\s+\d{3,4}$',main[0]):
             mainidx = 2
         else:
@@ -268,7 +268,7 @@ class Patent(PatentHandler):
                 {'id': "{class}/{subclass}".format(**data).upper()}])
             i = i + 1
         if self.xml.classification_national.further_classification:
-            further = self.xml.classification_national.contents_of('further_classification')
+            further = self.xml.classification_national.contents_of('further_classification', trim=False)
             for classification in further:
                 if re.search('^\s+\d{3,4}$',classification):
                     mainidx = 2

--- a/lib/handlers/grant_handler_v42.py
+++ b/lib/handlers/grant_handler_v42.py
@@ -375,7 +375,8 @@ class Patent(PatentHandler):
         """
         classes = []
         i = 0
-        main = self.xml.classification_national.contents_of('main_classification')
+        # Do not remove leading spaces from US main classification.
+        main = self.xml.classification_national.contents_of('main_classification', trim=False)
         crossrefsub = main[0][3:].replace(" ","")
         if len(crossrefsub) > 3 and re.search('^[A-Z]',crossrefsub[3:]) is None:
             crossrefsub = crossrefsub[:3]+'.'+crossrefsub[3:]
@@ -393,7 +394,8 @@ class Patent(PatentHandler):
                 {'id': "{class}/{subclass}".format(**data).upper()}])
             i = i + 1
         if self.xml.classification_national.further_classification:
-            further = self.xml.classification_national.contents_of('further_classification')
+            # Do not remove leading spaces from US further classification.
+            further = self.xml.classification_national.contents_of('further_classification', trim=False)
             for classification in further:
                 crossrefsub = classification[3:].replace(" ","")
                 if len(crossrefsub) > 3 and re.search('^[A-Z]',crossrefsub[3:]) is None:

--- a/lib/handlers/grant_handler_v44.py
+++ b/lib/handlers/grant_handler_v44.py
@@ -375,7 +375,7 @@ class Patent(PatentHandler):
         """
         classes = []
         i = 0
-        main = self.xml.classification_national.contents_of('main_classification')
+        main = self.xml.classification_national.contents_of('main_classification', trim=False)
         crossrefsub = main[0][3:].replace(" ","")
         if len(crossrefsub) > 3 and re.search('^[A-Z]',crossrefsub[3:]) is None:
             crossrefsub = crossrefsub[:3]+'.'+crossrefsub[3:]
@@ -392,7 +392,7 @@ class Patent(PatentHandler):
                 {'id': "{class}/{subclass}".format(**data).upper()}])
             i = i + 1
         if self.xml.classification_national.further_classification:
-            further = self.xml.classification_national.contents_of('further_classification')
+            further = self.xml.classification_national.contents_of('further_classification', trim=False)
             for classification in further:
                 crossrefsub = classification[3:].replace(" ","")
                 if len(crossrefsub) > 3 and re.search('^[A-Z]',crossrefsub[3:]) is None:

--- a/lib/handlers/xml_driver.py
+++ b/lib/handlers/xml_driver.py
@@ -46,10 +46,10 @@ class ChainList(list):
     a list in order to traverse the tree.
     """
 
-    def contents_of(self, tag, default=[''], as_string=False, upper=True):
+    def contents_of(self, tag, default=[''], as_string=False, upper=True, trim=True):
         res = []
         for item in self:
-            res.extend(item.contents_of(tag, upper=upper))
+            res.extend(item.contents_of(tag, upper=upper, trim=trim))
         if as_string:
             res = [r for r in res if type(r).__name__ not in ('tuple', 'list')]
             return ' '.join(res) if res else ''
@@ -106,10 +106,10 @@ class XMLElement(object):
         else:
             return ChainList('')
 
-    def contents_of(self, key, default=ChainList(''), as_string=False, upper=True):
+    def contents_of(self, key, default=ChainList(''), as_string=False, upper=True, trim=True):
         candidates = self.__getattr__(key)
         if candidates:
-            res = [x.get_content(upper=upper) for x in candidates]
+            res = [x.get_content(upper=upper, trim=trim) for x in candidates]
         else:
             res = default
         if as_string:
@@ -123,11 +123,11 @@ class XMLElement(object):
             return ' '.join(filter(lambda x: x, filter(lambda x: not isinstance(x, list), res)))
         return res
 
-    def get_content(self, upper=True):
+    def get_content(self, upper=True, trim=True):
         if len(self.content) == 1:
-            return xml_util.clean(self.content[0], upper=upper)
+            return xml_util.clean(self.content[0], upper=upper, trim=trim)
         else:
-            return map(functools.partial(xml_util.clean, upper=upper), self.content)
+            return map(functools.partial(xml_util.clean, upper=upper, trim=trim), self.content)
 
     def put_content(self, content, lastlinenumber, linenumber):
         if not self.content or lastlinenumber != linenumber:
@@ -138,8 +138,8 @@ class XMLElement(object):
     def add_child(self, child):
         self.children.append(child)
 
-    def get_attribute(self, key, upper=True):
-        return xml_util.clean(self._attributes.get(key, None), upper=upper)
+    def get_attribute(self, key, upper=True, trim=True):
+        return xml_util.clean(self._attributes.get(key, None), upper=upper, trim=trim)
 
     def get_xmlelements(self, name):
         return filter(lambda x: x._name == name, self.children) \

--- a/lib/handlers/xml_util.py
+++ b/lib/handlers/xml_util.py
@@ -135,7 +135,7 @@ def associate_prefix(firstname, lastname):
     last = prefix+space+lastname
     return name, last
 
-def clean(string, upper=True):
+def clean(string, upper=True, trim=True):
     """
     Applies a subset of the above functions in the correct order
     and returns the string in all uppercase.
@@ -143,7 +143,10 @@ def clean(string, upper=True):
     Change &amp;
     """
     string = normalize_utf8(string)
-    string = remove_escape_sequences(string)
+    if trim:
+        string = remove_escape_sequences(string)
+    else:
+        string = string.rstrip() # Preserve leading spaces
     string = translate_underscore(string)
     string = escape_html(string)
     string = string.replace("&nbsp;", " ").replace("&amp;", "&")


### PR DESCRIPTION
This request resolves a bug (Issue #1) that caused incorrect parsing of strings containing US patent classifications when the strings have two leading spaces. The changes prevent the function `xml_util.clean()` from removing leading spaces from these strings, but they do allow removal of trailing whitespace. These changes have not been tested yet.
